### PR TITLE
Add spawnable floating money leaderboard

### DIFF
--- a/data/datapack3/functions/ci_test.mcfunction
+++ b/data/datapack3/functions/ci_test.mcfunction
@@ -1,5 +1,37 @@
-﻿say [datapack3] ci_test start
-# Add quick smoke checks below (examples):
-# scoreboard objectives add money dummy
-# function datapack3:some_feature_smoke
+say [datapack3] ci_test start
+function datapack3:leaderboard/setup
+
+summon minecraft:player ~ ~ ~ {player_name:"Alice"}
+summon minecraft:player ~ ~ ~ {player_name:"Bob"}
+summon minecraft:player ~ ~ ~ {player_name:"Carol"}
+
+scoreboard players set Alice money 12345
+scoreboard players set Bob money 6789
+scoreboard players set Carol money 400
+
+function datapack3:leaderboard/update
+
+execute unless score @e[type=minecraft:player,name="Alice",limit=1] lb_board_rank matches 1 run return fail
+execute unless score @e[type=minecraft:player,name="Bob",limit=1] lb_board_rank matches 2 run return fail
+execute unless score @e[type=minecraft:player,name="Carol",limit=1] lb_board_rank matches 3 run return fail
+
+execute unless score @e[type=minecraft:player,name="Alice",limit=1] lb_money_int matches 123 run return fail
+execute unless score @e[type=minecraft:player,name="Alice",limit=1] lb_money_frac_tens matches 4 run return fail
+execute unless score @e[type=minecraft:player,name="Alice",limit=1] lb_money_frac_ones matches 5 run return fail
+
+execute unless score @e[type=minecraft:player,name="Bob",limit=1] lb_money_int matches 67 run return fail
+execute unless score @e[type=minecraft:player,name="Bob",limit=1] lb_money_frac_tens matches 8 run return fail
+execute unless score @e[type=minecraft:player,name="Bob",limit=1] lb_money_frac_ones matches 9 run return fail
+
+execute unless score @e[type=minecraft:player,name="Carol",limit=1] lb_money_int matches 4 run return fail
+execute unless score @e[type=minecraft:player,name="Carol",limit=1] lb_money_frac_tens matches 0 run return fail
+execute unless score @e[type=minecraft:player,name="Carol",limit=1] lb_money_frac_ones matches 0 run return fail
+
+execute unless data storage datapack3:leaderboard text{extra:[{"text":"Money Leaderboard","color":"gold","bold":true}]} run return fail
+
+kill @e[type=minecraft:player,name="Alice"]
+kill @e[type=minecraft:player,name="Bob"]
+kill @e[type=minecraft:player,name="Carol"]
+kill @e[type=minecraft:text_display,tag=datapack3.leaderboard]
+
 say [datapack3] ci_test done

--- a/data/datapack3/functions/leaderboard/clear.mcfunction
+++ b/data/datapack3/functions/leaderboard/clear.mcfunction
@@ -1,0 +1,1 @@
+kill @e[type=minecraft:text_display,tag=datapack3.leaderboard]

--- a/data/datapack3/functions/leaderboard/debug_dump.mcfunction
+++ b/data/datapack3/functions/leaderboard/debug_dump.mcfunction
@@ -1,0 +1,2 @@
+function datapack3:leaderboard/update
+tellraw @s {"nbt":"text","storage":"datapack3:leaderboard","interpret":true}

--- a/data/datapack3/functions/leaderboard/setup.mcfunction
+++ b/data/datapack3/functions/leaderboard/setup.mcfunction
@@ -1,0 +1,19 @@
+scoreboard objectives add money dummy {"text":"Money (¢)"}
+scoreboard objectives add lb_money_int dummy
+scoreboard objectives add lb_money_frac dummy
+scoreboard objectives add lb_money_frac_tens dummy
+scoreboard objectives add lb_money_frac_ones dummy
+scoreboard objectives add lb_board_rank dummy
+scoreboard objectives add lb_board_best dummy
+scoreboard objectives add lb_state dummy
+scoreboard objectives add lb_const dummy
+
+data modify storage datapack3:leaderboard initialized set value 1b
+
+data modify storage datapack3:leaderboard text set value {"text":"","extra":[]}
+
+scoreboard players set #hundred lb_const 100
+scoreboard players set #ten lb_const 10
+scoreboard players set #limit lb_state 10
+scoreboard players set #best_score lb_state -2147483648
+scoreboard players set #rank lb_state 0

--- a/data/datapack3/functions/leaderboard/spawn.mcfunction
+++ b/data/datapack3/functions/leaderboard/spawn.mcfunction
@@ -1,0 +1,1 @@
+summon minecraft:text_display ~ ~2 ~ {billboard:"vertical",line_width:200,background:0,shadow:0,tags:["datapack3.leaderboard"],text:{"text":"","color":"white"}}

--- a/data/datapack3/functions/leaderboard/update.mcfunction
+++ b/data/datapack3/functions/leaderboard/update.mcfunction
@@ -1,0 +1,4 @@
+function datapack3:leaderboard/update/prepare_scores
+function datapack3:leaderboard/update/rank
+function datapack3:leaderboard/update/build_text
+execute as @e[type=minecraft:text_display,tag=datapack3.leaderboard] run data modify entity @s text set from storage datapack3:leaderboard text

--- a/data/datapack3/functions/leaderboard/update/build_text.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/build_text.mcfunction
@@ -1,0 +1,13 @@
+data modify storage datapack3:leaderboard text set value {"text":"","extra":[]}
+data modify storage datapack3:leaderboard text.extra append value {"text":"Money Leaderboard","color":"gold","bold":true}
+
+execute as @a[scores={lb_board_rank=1}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=2}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=3}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=4}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=5}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=6}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=7}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=8}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=9}] run function datapack3:leaderboard/update/build_text/append_line
+execute as @a[scores={lb_board_rank=10}] run function datapack3:leaderboard/update/build_text/append_line

--- a/data/datapack3/functions/leaderboard/update/build_text/append_line.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/build_text/append_line.mcfunction
@@ -1,0 +1,2 @@
+data modify storage datapack3:leaderboard text.extra append value {"text":"\n"}
+data modify storage datapack3:leaderboard text.extra append value {"text":"","extra":[{"score":{"name":"*","objective":"lb_board_rank"},"color":"gray"},{"text":". ","color":"gray"},{"selector":"@s","color":"white"},{"text":" ("},{"score":{"name":"*","objective":"lb_money_int"}},{"text":"."},{"score":{"name":"*","objective":"lb_money_frac_tens"}},{"score":{"name":"*","objective":"lb_money_frac_ones"}},{"text":"$)"}]}

--- a/data/datapack3/functions/leaderboard/update/prepare_scores.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/prepare_scores.mcfunction
@@ -1,0 +1,16 @@
+execute as @a run scoreboard players add @s money 0
+execute as @a run scoreboard players set @s lb_board_rank 0
+execute as @a run scoreboard players set @s lb_board_best 0
+execute as @a run scoreboard players set @s lb_money_int 0
+execute as @a run scoreboard players set @s lb_money_frac 0
+execute as @a run scoreboard players set @s lb_money_frac_tens 0
+execute as @a run scoreboard players set @s lb_money_frac_ones 0
+
+execute as @a run scoreboard players operation @s lb_money_int = @s money
+execute as @a run scoreboard players operation @s lb_money_frac = @s money
+execute as @a run scoreboard players operation @s lb_money_int /= #hundred lb_const
+execute as @a run scoreboard players operation @s lb_money_frac %= #hundred lb_const
+execute as @a run scoreboard players operation @s lb_money_frac_tens = @s lb_money_frac
+execute as @a run scoreboard players operation @s lb_money_frac_tens /= #ten lb_const
+execute as @a run scoreboard players operation @s lb_money_frac_ones = @s lb_money_frac
+execute as @a run scoreboard players operation @s lb_money_frac_ones %= #ten lb_const

--- a/data/datapack3/functions/leaderboard/update/rank.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/rank.mcfunction
@@ -1,0 +1,2 @@
+scoreboard players set #rank lb_state 1
+function datapack3:leaderboard/update/rank_loop

--- a/data/datapack3/functions/leaderboard/update/rank_loop.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/rank_loop.mcfunction
@@ -1,0 +1,12 @@
+execute if score #rank lb_state > #limit lb_state run return
+execute unless entity @a[scores={lb_board_rank=0}] run return
+
+scoreboard players set #best_score lb_state -2147483648
+scoreboard players set @a[scores={lb_board_rank=0}] lb_board_best 0
+
+execute as @a[scores={lb_board_rank=0}] run function datapack3:leaderboard/update/rank_select_best
+
+scoreboard players operation @a[scores={lb_board_best=1}] lb_board_rank = #rank lb_state
+scoreboard players set @a[scores={lb_board_best=1}] lb_board_best 0
+scoreboard players add #rank lb_state 1
+function datapack3:leaderboard/update/rank_loop

--- a/data/datapack3/functions/leaderboard/update/rank_select_best.mcfunction
+++ b/data/datapack3/functions/leaderboard/update/rank_select_best.mcfunction
@@ -1,0 +1,4 @@
+execute if score @s money > #best_score lb_state run scoreboard players set @a[scores={lb_board_rank=0}] lb_board_best 0
+execute if score @s money > #best_score lb_state run scoreboard players operation #best_score lb_state = @s money
+execute if score @s money > #best_score lb_state run scoreboard players set @s lb_board_best 1
+execute if score @s money = #best_score lb_state run scoreboard players set @s lb_board_best 1

--- a/data/datapack3/functions/load.mcfunction
+++ b/data/datapack3/functions/load.mcfunction
@@ -1,0 +1,1 @@
+execute unless data storage datapack3:leaderboard {initialized:1b} run function datapack3:leaderboard/setup

--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "datapack3:load"
+  ]
+}

--- a/data/minecraft/tags/functions/tick.json
+++ b/data/minecraft/tags/functions/tick.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "datapack3:leaderboard/update"
+  ]
+}


### PR DESCRIPTION
## Summary
- add load and tick hooks so the leaderboard objectives initialize once and refresh every tick
- implement money leaderboard functions for ranking players, formatting (X.XX$) text, spawning/clearing the floating display, and dumping the board to chat for debugging
- expand the ci_test function to cover the leaderboard setup, ranking logic, and decimal formatting helpers

## Testing
- not run (Minecraft runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3210aca9c832385713250955d2d3a